### PR TITLE
feat: 勾配プロフィール描画時の数値表示カスタマイズ機能を追加

### DIFF
--- a/src/app/profile-side/controller.module.css
+++ b/src/app/profile-side/controller.module.css
@@ -2,4 +2,5 @@
   background: #ffffff;
   width: fit-content;
   padding: 4px;
+  min-width: 140px;
 }

--- a/src/app/profile-side/controller.tsx
+++ b/src/app/profile-side/controller.tsx
@@ -6,7 +6,7 @@ export default function ControllerView() {
   return (
     <div className={styles.outer}>
       <ColorSelector />
-      {/* <DrawStatus /> */}
+      <DrawStatus />
     </div>
   );
 }

--- a/src/app/profile-side/elevation2D.tsx
+++ b/src/app/profile-side/elevation2D.tsx
@@ -1,4 +1,4 @@
-import { useAppStore, useColorState } from '@/lib/store';
+import { DrawState, useAppStore, useColorState, useDrawState } from '@/lib/store';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './elevation2D.module.css';
 import { RouteData } from '@/lib/types';
@@ -9,6 +9,7 @@ export function Draw2View() {
   const [height, setHeight] = useState(0);
 
   const { colorFromSlope } = useColorState();
+  const drawState = useDrawState();
 
   const route = useAppStore((st) => st.routeDataInRange());
 
@@ -40,7 +41,8 @@ export function Draw2View() {
           route.minElevation - 100,
           route.maxElevation + 100,
           1000,
-          colorFromSlope
+          colorFromSlope,
+          drawState
         )}
     </div>
   );
@@ -58,7 +60,8 @@ function createProfile(
   bottomEle: number,
   topEle: number,
   distanceUnit: number,
-  colorFromSlope: (slope: number) => string
+  colorFromSlope: (slope: number) => string,
+  drawState: DrawState
 ) {
   const svg = [];
   const startX = marginX; // 描画範囲の左上
@@ -162,9 +165,10 @@ function createProfile(
       <text
         x={d1.x + (d2.x - d1.x) / 2}
         y={endY - 20}
-        fill="white"
-        fontSize="30px"
+        fill={drawState.slopeColor}
+        fontSize={drawState.slopeFontSize + 'px'}
         style={{ fontWeight: 'bold', textAnchor: 'middle' }}
+        key={`text-slope-${i}`}
       >
         {d2.slope.toFixed(1)}
       </text>
@@ -175,15 +179,23 @@ function createProfile(
   // TODO: 1km単位前提の処理になっているため、後で修正する
   for (let i = 0; i < drawData.length; i++) {
     const d = drawData[i];
+    let t = (d.distance / 1000).toFixed(1);
+    // 端数省略設定時、小数点第一位が「0」だったら省略する。
+    if (drawState.fractionOmitFlag) {
+      if (t.endsWith('.0')) {
+        t = (d.distance / 1000).toFixed(0);
+      }
+    }
     svg.push(
       <text
         x={d.x}
         y={endY + 26}
         fill="black"
-        fontSize="20px"
+        fontSize={drawState.distanceFontSize + 'px'}
         style={{ fontWeight: 'bold', textAnchor: 'middle' }}
+        key={`text-distance-${i}`}
       >
-        {(d.distance / 1000).toFixed(1) + 'km'}
+        {t + 'km'}
       </text>
     );
   }

--- a/src/components/drawStatus.module.css
+++ b/src/components/drawStatus.module.css
@@ -2,12 +2,32 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   width: 100%;
-  padding: 4px;
+}
+
+.title {
+  font-size: 90%;
+  font-weight: bold;
+  padding-left: 4px;
+  background: #555;
+  color: white;
+}
+
+.category {
+  background: #ccc;
+  font-size: small;
+  font-weight: bold;
 }
 
 .label {
   font-size: small;
-  font-weight: bold;
+  font-weight: normal;
+}
+
+.inner {
+  margin: 2px 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 /* .slider {

--- a/src/components/drawStatus.tsx
+++ b/src/components/drawStatus.tsx
@@ -1,6 +1,7 @@
 import { DistanceUnit } from '@/lib/constants';
 import styles from './drawStatus.module.css';
 import { useAppStore, useDrawState } from '@/lib/store';
+import { useState } from 'react';
 
 const MARGIN_LEFT = 100;
 const MARGIN_RIGHT = 100;
@@ -9,15 +10,35 @@ const MARGIN_BOTTOM = 100;
 
 export default function DrawStatus() {
   const draw = useDrawState();
+  const [slopeFontSize, setSlopeFontSize] = useState(String(draw.slopeFontSize));
+  const [distanceFontSize, setDistanceFontSize] = useState(String(draw.distanceFontSize));
 
   function unitChanged(e: React.ChangeEvent<HTMLSelectElement>) {
     const v = e.target.value;
     draw.changeUnit(v);
   }
 
+  function slopeFontSizeChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setSlopeFontSize(v);
+    const n = Number(v);
+    if (n !== 0) {
+      draw.setSlopeFontSize(n);
+    }
+  }
+
+  function distanceFontSizeChanged(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setDistanceFontSize(v);
+    const n = Number(v);
+    if (n !== 0) {
+      draw.setDistanceFontSize(n);
+    }
+  }
+
   return (
     <div className={styles.box}>
-      <div>
+      {/* <div>
         <label className={styles.label} htmlFor="distance-unit">
           距離単位
         </label>
@@ -30,102 +51,51 @@ export default function DrawStatus() {
       </div>
       <label className={styles.label} htmlFor="start">
         最後から、最初から
-      </label>
+      </label> */}
+      <h2 className={styles.title}>プロフィール</h2>
+      <h3 className={styles.category}>斜度</h3>
+      <div className={styles.inner}>
+        <label className={styles.label}>サイズ</label>
+        <input
+          type="number"
+          id="slope-font-size"
+          value={slopeFontSize}
+          min="6"
+          max="36"
+          size={5}
+          onChange={slopeFontSizeChanged}
+        />
+      </div>
+      <div className={styles.inner}>
+        <label className={styles.label}>色</label>
+        <input
+          type="color"
+          value={draw.slopeColor}
+          onChange={(e) => draw.setSlopeColor(e.currentTarget.value)}
+        />
+      </div>
+      <h3 className={styles.category}>距離</h3>
+      <div className={styles.inner}>
+        <label className={styles.label}>サイズ</label>
+        <input
+          type="number"
+          id="distance-font-size"
+          value={distanceFontSize}
+          min="6"
+          max="36"
+          size={5}
+          onChange={distanceFontSizeChanged}
+        />
+      </div>
+      <div className={styles.inner}>
+        <label className={styles.label}>端数省略</label>
+        <input
+          type="checkbox"
+          id="fraction-omit"
+          checked={draw.fractionOmitFlag}
+          onChange={(e) => draw.setFractionOmitFlag(!draw.fractionOmitFlag)}
+        />
+      </div>
     </div>
   );
-  // const [rangeStart, setRangeStart] = useAppStore((state) => [
-  //   state.rangeStart,
-  //   state.setRangeStart,
-  // ]);
-  // const [rangeEnd, setRangeEnd] = useAppStore((state) => [
-  //   state.rangeEnd,
-  //   state.setRangeEnd,
-  // ]);
-  // const [modRangeStart, modRangeEnd] = useAppStore((st) => [
-  //   st.modRangeStart,
-  //   st.modRangeEnd,
-  // ]);
-  // const rangeMax = useAppStore((state) => state.gpxData?.points.length) || 1;
-  // const gpxData = useAppStore((state) => state.gpxData);
-
-  // let kmStart = '???';
-  // let kmEnd = '???';
-  // if (gpxData) {
-  //   const st = gpxData.points[rangeStart].dist;
-  //   const en = gpxData.points[rangeEnd].dist;
-  //   kmStart = `${(st / 1000).toFixed(2)}km`;
-  //   kmEnd = `${(en / 1000).toFixed(2)}km`;
-  // }
-
-  // const handleChangeStart = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   const v = Number(e.target.value);
-  //   if (v < rangeEnd) {
-  //     setRangeStart(v);
-  //   }
-  // };
-  // const handleChangeEnd = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   const v = Number(e.target.value);
-  //   if (rangeStart < v) {
-  //     setRangeEnd(v);
-  //   }
-  // };
-
-  // return (
-  //   <div className={styles.box}>
-  //     <p className={styles.label}>表示範囲指定</p>
-  //     <label htmlFor="startPoint" className={styles.rangeLabel}>
-  //       開始:
-  //       <button className={styles.modButton} onClick={() => modRangeStart(-5)}>
-  //         -5
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeStart(-1)}>
-  //         -1
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeStart(1)}>
-  //         +1
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeStart(5)}>
-  //         +5
-  //       </button>
-  //       &nbsp;
-  //       {kmStart}
-  //     </label>
-  //     <input
-  //       type="range"
-  //       id="startPoint"
-  //       className={styles.slider}
-  //       min="0"
-  //       max={rangeMax}
-  //       value={rangeStart}
-  //       onChange={handleChangeStart}
-  //     />
-  //     <br />
-  //     <label htmlFor="endPoint" className={styles.rangeLabel}>
-  //       終了:
-  //       <button className={styles.modButton} onClick={() => modRangeEnd(-5)}>
-  //         -5
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeEnd(-1)}>
-  //         -1
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeEnd(1)}>
-  //         +1
-  //       </button>
-  //       <button className={styles.modButton} onClick={() => modRangeEnd(5)}>
-  //         +5
-  //       </button>
-  //       &nbsp;
-  //       {kmEnd}
-  //     </label>
-  //     <input
-  //       type="range"
-  //       id="endPoint"
-  //       className={styles.slider}
-  //       min="0"
-  //       max={rangeMax - 1}
-  //       value={rangeEnd}
-  //       onChange={handleChangeEnd}
-  //     />
-  //   </div>
-  // );
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -240,13 +240,27 @@ export type DrawState = {
   width: number;
   height: number;
   unit: DistanceUnit;
+  slopeFontSize: number;
+  slopeColor: string;
+  distanceFontSize: number;
+  /** 距離の端数を省略するかどうかのフラグ。 */
+  fractionOmitFlag: boolean;
+
   changeUnit: (v: string | number) => void;
+  setSlopeFontSize: (size: number) => void;
+  setSlopeColor: (color: string) => void;
+  setDistanceFontSize: (size: number) => void;
+  setFractionOmitFlag: (flag: boolean) => void;
 };
 
 export const useDrawState = create<DrawState>((set, get) => ({
   width: 600,
   height: 400,
   unit: DistanceUnit.M1000,
+  slopeFontSize: 18,
+  slopeColor: '#FFFFFF',
+  distanceFontSize: 20,
+  fractionOmitFlag: true,
 
   changeUnit(v) {
     const n = Number(v);
@@ -264,5 +278,21 @@ export const useDrawState = create<DrawState>((set, get) => ({
         set(() => ({ unit: DistanceUnit.M1000 }));
         break;
     }
+  },
+
+  setSlopeFontSize(size) {
+    set(() => ({ slopeFontSize: size }));
+  },
+
+  setSlopeColor(color) {
+    set(() => ({ slopeColor: color }));
+  },
+
+  setDistanceFontSize(size) {
+    set(() => ({ distanceFontSize: size }));
+  },
+
+  setFractionOmitFlag(flag) {
+    set(() => ({ fractionOmitFlag: flag }));
   },
 }));


### PR DESCRIPTION
勾配プロフィールの描画において、以下のカスタム機能を追加。

- 勾配表示
  - フォントサイズ
  - フォントカラー
- 距離表示
  - フォントサイズ
  - 端数（小数点第一位）が 0 のときの省略表示